### PR TITLE
Add revenue generation brainstorm document

### DIFF
--- a/REVENUE_IDEAS.md
+++ b/REVENUE_IDEAS.md
@@ -1,0 +1,263 @@
+# Revenue Generation Ideas for FreeInvoice
+
+## Overview
+
+This document brainstorms monetization strategies for the FreeInvoice invoice generator. The app currently markets itself as "completely free forever," so any revenue strategy must carefully preserve the free core while creating genuine value in paid tiers.
+
+The good news: significant monetization infrastructure is **already in place** in the codebase — much of this is activation work, not greenfield development.
+
+---
+
+## Existing Monetization Infrastructure (Already Built)
+
+| Feature | Location | Status |
+|---|---|---|
+| Cloud sync limit (10 invoices) | `src/lib/server/db.ts` (`INVOICE_LIMIT = 10`) | Enforced |
+| Premium template flags | `src/lib/templates/registry.ts` (`premium: true`) | Flagged, not gated |
+| Auth system (Google OAuth) | Better Auth + Cloudflare D1 | Fully working |
+| "Coming Soon: Billing" section | `src/routes/dashboard/settings/+page.svelte` | Placeholder |
+| Sign-up upsell modal | `src/components/SignUpPromptModal.svelte` | Working |
+| Invoice share links | `src/components/ShareInvoiceModal.svelte` | Working (30-day expiry) |
+| Email invoice modal | `src/components/SendEmailModal.svelte` | Stub ("coming soon") |
+| PDF microservice key | `.env.example` (`PDF_MICROSERVICE_API_KEY`) | Stub |
+| Admin dashboard | `src/routes/admin/+page.svelte` | Fully working |
+
+---
+
+## Phase 1 — Quick Wins (Low effort, activate existing infrastructure)
+
+### 1. Premium Template Gating
+
+**What**: Gate the 3 templates already flagged `premium: true` (Classic, Minimal, Atlantic) behind a Pro plan or one-time purchase.
+
+**Why now**: The registry already marks them as premium. Only enforcement logic is missing.
+
+**Implementation**:
+- `src/lib/templates/registry.ts` — Already has `premium: true` flags
+- `src/components/TemplateSelector.svelte` — Add plan check; show upgrade modal for non-Pro users
+- New `UpgradeModal.svelte` — Simple upsell prompt ("Unlock all templates with Pro")
+
+**Revenue model**: Included in Pro plan, or $4.99 one-time unlock.
+
+---
+
+### 2. Freemium Cloud Sync Tiers
+
+**What**: The 10-invoice cloud sync limit is already enforced. Introduce paid tiers to increase the limit.
+
+| Plan | Price | Cloud Invoices |
+|---|---|---|
+| Free | $0 | 10 |
+| Pro | $5/mo | 100 |
+| Business | $12/mo | Unlimited |
+
+**Implementation**:
+- `src/lib/server/db.ts` — Replace hard-coded `INVOICE_LIMIT = 10` with per-user plan lookup
+- Database schema — Add `plan`, `planExpiry`, `stripeCustomerId` to users table
+- `src/routes/dashboard/settings/+page.svelte` — Replace "Coming Soon: Billing" with Stripe Checkout / Paddle
+
+**Revenue model**: Monthly subscription (Stripe or Paddle).
+
+---
+
+### 3. Donate / Tip Jar
+
+**What**: Add a low-friction "Support this project" donate button. Respects the free-forever brand while capturing value from grateful users.
+
+**Implementation**:
+- Add "Buy us a coffee" button (Ko-fi / GitHub Sponsors / Stripe one-time link) to the footer or settings page
+- One paragraph of copy: "FreeInvoice is free forever. If it saves you time, consider buying the team a coffee."
+
+**Revenue model**: One-time donations ($3–$10 typical).
+
+---
+
+## Phase 2 — Core Monetization (Medium effort, strong recurring revenue)
+
+### 4. Email Invoice Sending
+
+**What**: `SendEmailModal.svelte` already exists with a "coming soon" stub. Implement real email delivery as a Pro feature.
+
+- **Free**: Download PDF only
+- **Pro**: Send invoices directly to clients via email (50/mo)
+- **Business**: Unlimited sends + custom sender domain
+
+**Implementation**:
+- `src/components/SendEmailModal.svelte` — Replace stub with real API call
+- New `/api/invoices/[id]/email` endpoint — Integrate SendGrid or Resend
+- Add `emailsSentThisMonth` counter to user record for quota enforcement
+
+**Revenue model**: Included in Pro/Business plan.
+
+---
+
+### 5. High-Quality Server-Side PDF Export
+
+**What**: `.env.example` already has `PDF_MICROSERVICE_API_KEY`. Use a headless Chrome microservice (e.g., Browserless.io, Gotenberg) for pixel-perfect PDFs vs. the current client-side html2pdf.js.
+
+- **Free**: Client-side html2pdf.js (current — good but not print-perfect)
+- **Pro**: Server-rendered PDF via microservice (crisp fonts, exact colors, proper bleed)
+
+**Implementation**:
+- `/api/invoices/[id]/download` — Wire up microservice when user is Pro
+- `src/routes/+page.svelte` — Show "High-Quality PDF" button for Pro users
+
+**Revenue model**: Included in Pro plan. Also a strong upsell hook.
+
+---
+
+### 6. Enhanced Share Links
+
+**What**: The share link system is fully built (30-day expiry, view tracking). Monetize advanced options.
+
+| Feature | Free | Pro | Business |
+|---|---|---|---|
+| Share link expiry | 30 days | 90 days | Never |
+| Password protection | — | ✓ | ✓ |
+| View analytics dashboard | Basic | Full | Full |
+| Custom domain | — | — | ✓ |
+
+**Implementation**:
+- `src/components/ShareInvoiceModal.svelte` — Add password field + extended expiry options (gated)
+- `/api/invoices/[id]/share` — Add `password`, `expiryDays` fields to schema
+- New `/dashboard/analytics` page for Pro users
+
+**Revenue model**: Included in Pro/Business plan.
+
+---
+
+## Phase 3 — Growth Features (Higher effort, strong retention)
+
+### 7. Recurring Invoice Automation
+
+**What**: Allow Pro users to create invoice templates that auto-generate on a schedule (weekly, monthly, quarterly). Critical for freelancers with retainer clients.
+
+**Implementation**:
+- New `recurringInvoices` table in D1 — `invoiceId`, `frequency`, `nextRunAt`, `lastRunAt`
+- Cloudflare Workers Cron Trigger — Check and generate due invoices daily
+- UI in `/dashboard` to manage recurring invoices
+
+**Revenue model**: Pro/Business plan feature. Strong retention driver.
+
+---
+
+### 8. White-Label / Remove Branding
+
+**What**: Let businesses remove "FreeInvoice.info" footer branding from PDFs and use their own logo/colors.
+
+**Implementation**:
+- Add `removeBranding: boolean` to user plan settings
+- Invoice templates — Conditionally render footer branding based on plan
+- Branding settings page — Custom accent color, default logo
+
+**Revenue model**: Business plan only, or $9.99/mo add-on.
+
+---
+
+### 9. Client Portal
+
+**What**: A branded public page (`/portal/[clientSlug]`) where a freelancer's clients can log in to view, download, and pay all their invoices.
+
+**Implementation**:
+- New route `/portal/[slug]` — Public-facing client invoice list
+- Magic link auth for clients (no password needed)
+- Drives significant organic SEO traffic ("invoice portal for clients")
+
+**Revenue model**: Business plan feature.
+
+---
+
+## Phase 4 — Scale (Longer-term, high leverage)
+
+### 10. Developer API
+
+**What**: Expose invoice creation and PDF generation as a REST API for developers building billing integrations (e.g., auto-generate invoices from Stripe payments).
+
+- Pay-per-use: $0.05/invoice generated, $0.10/PDF rendered
+- Or subscription: $29/mo for 1,000 API calls/mo
+
+**Implementation**:
+- API key management in `/dashboard/settings`
+- Rate limiting and usage tracking per API key
+- Developer docs page
+
+---
+
+### 11. Team / Agency Plan
+
+**What**: Multi-user accounts where a team shares an invoice pool, templates, and client list.
+
+| Feature | Business | Team |
+|---|---|---|
+| Users | 1 | Up to 10 |
+| Shared invoice pool | — | ✓ |
+| Shared template library | — | ✓ |
+| Role-based permissions | — | ✓ |
+
+**Revenue model**: $29/mo for up to 10 seats.
+
+---
+
+### 12. One-Time Lifetime Deal
+
+**What**: Sell lifetime Pro access for a one-time payment ($49) via AppSumo or direct.
+
+- Strong for bootstrapped SaaS — cash upfront, no churn
+- Works well with the current "small business / freelancer" audience
+- AppSumo audience actively looks for lifetime deals on productivity tools
+
+---
+
+### 13. Template Marketplace
+
+**What**: Let third-party designers submit and sell invoice templates through an in-app marketplace.
+
+- Revenue share: 70% to designer, 30% to platform
+- Expands the template library at zero development cost
+- Creates a community flywheel
+
+---
+
+## Recommended Implementation Roadmap
+
+```
+Phase 1 (Weeks 1–2): Quick wins
+  ├── Premium template gating (registry already done, just add enforcement)
+  ├── Freemium cloud sync tiers (limit already enforced, add Stripe)
+  └── Donate button in footer/settings
+
+Phase 2 (Weeks 3–6): Core monetization
+  ├── Stripe/Paddle subscription integration
+  ├── Email invoice sending (modal stub already exists)
+  ├── High-quality PDF microservice (env key already stubbed)
+  └── Enhanced share links (system already built)
+
+Phase 3 (Weeks 7–12): Growth
+  ├── Recurring invoice automation
+  ├── White-label / branding removal
+  └── Client portal
+
+Phase 4 (Months 4+): Scale
+  ├── Developer API + docs
+  ├── Team/agency plan
+  ├── Lifetime deal campaign (AppSumo)
+  └── Template marketplace
+```
+
+---
+
+## Suggested Pricing Structure
+
+| Plan | Price | Key Limits |
+|---|---|---|
+| **Free** | $0/forever | 10 cloud invoices, 4 free templates, PDF download only |
+| **Pro** | $5/mo or $48/yr | 100 cloud invoices, all templates, email sending, server PDF |
+| **Business** | $12/mo or $99/yr | Unlimited invoices, white-label, custom share domain, analytics |
+| **Team** | $29/mo | Business features × 10 users, shared workspace |
+| **Lifetime** | $49 one-time | Pro features, forever |
+
+---
+
+## Key Principle
+
+> Keep the free tier genuinely useful. The goal is to make paid tiers feel like a natural upgrade for growing businesses — not to cripple the free experience. Freelancers and small businesses trust this tool because it's free and private; that trust is the most valuable asset.


### PR DESCRIPTION
Documents 14 revenue ideas organized into 4 phases, from quick wins
(premium template gating, freemium cloud sync tiers, donate button)
to longer-term scale plays (developer API, team plans, marketplace).
Includes pricing structure, implementation roadmap, and references to
existing monetization infrastructure already in the codebase.

https://claude.ai/code/session_01HHruYUveum7rYiHGAouR2s